### PR TITLE
docs: fix issue links to use full syntax (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 In order to contribute code to ReteLabs open-source projects, you need to sign Contributor License Agreement.
 
-TODO: define proper legal guide, CLA (#1)
+TODO: define proper legal guide, CLA (rete-labs/onboarding#1)
 
 ## Technical
 
@@ -50,7 +50,7 @@ Use Flor Сomponent API to implement async-echo:
 
 Use Flor Capabilities API to implement advanced async-echo.
 
-TODO: define details of task 3 to practice Flor Capabilities API (#3)
+TODO: define details of task 3 to practice Flor Capabilities API (rete-labs/onboarding#3)
 
 ### Intro to Florete Forwarding
 
@@ -60,4 +60,4 @@ Use Florete Portal API (publish/connect capabilities) and F-tunnels (Florete Tun
 
 ## Development Environment
 
-TODO: describe setup of development environment (#4)
+TODO: describe setup of development environment (rete-labs/onboarding#4)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ In order to contribute code to ReteLabs open-source projects, you need to sign C
 
 TODO: define proper legal guide, CLA (rete-labs/onboarding#1)
 
+Why simple #1 (#1) #2 #4 (#4) not working?
+
 ## Technical
 
 ### Rust Basics

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ In order to contribute code to ReteLabs open-source projects, you need to sign C
 
 TODO: define proper legal guide, CLA (rete-labs/onboarding#1)
 
-Why simple #1 (#1) #2 #4 (#4) not working?
-
 ## Technical
 
 ### Rust Basics


### PR DESCRIPTION
This PR fixes links to TODO issues in the guide (README.md).

Short links like rete-labs/florete#20, rete-labs/onboarding#2 do not work in this context. Full links rete-labs/onboarding#2 work fine, so they're used now.

Fixes rete-labs/onboarding#2 